### PR TITLE
fix: 実機テストフィードバック対応（VISUALIZE L/Rパネル・音声有効化UI・LP図削除）

### DIFF
--- a/examples/VISUALIZE/index.html
+++ b/examples/VISUALIZE/index.html
@@ -19,7 +19,7 @@
     </nav>
 
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-6" id="panel0">
         <div id="toolkit0" class="mb-2"></div>
         <canvas id="chart0_press"></canvas>
         <canvas id="chart0_acc"></canvas>
@@ -28,7 +28,7 @@
         <canvas id="chart0_euler"></canvas>
       </div>
 
-      <div class="col-md-6">
+      <div class="col-md-6" id="panel1">
         <div id="toolkit1" class="mb-2"></div>
         <canvas id="chart1_press"></canvas>
         <canvas id="chart1_acc"></canvas>

--- a/examples/VISUALIZE/sketch.js
+++ b/examples/VISUALIZE/sketch.js
@@ -84,6 +84,38 @@ class ChartFeed {
 
 const feeds = []; // feeds[id] = {press, acc, gyro, quat, euler}
 
+/**
+ * 装着位置（mount_position bit0: 0=LEFT, 1=RIGHT）に合わせて、
+ * 左足デバイスのパネルを画面左、右足デバイスのパネルを画面右に並べ替える。
+ * どちらのトグルから接続しても、表示位置は実際の左右に追従する。
+ */
+function updatePanelOrder() {
+    for (let id = 0; id < 2; id++) {
+        const panel = document.getElementById(`panel${id}`);
+        if (!panel) continue;
+        const info = insoles[id].device_information;
+        let order = id; // 未接続・左右不明時は元の並び
+        if (info && typeof info.mount_position !== 'undefined') {
+            order = (info.mount_position & 0b1) === 1 ? 1 : 0; // L=左列, R=右列
+        }
+        panel.style.order = order;
+    }
+}
+
+/**
+ * device_information は begin() の接続処理の中で onConnect の後に取得されるため、
+ * mount_position が入るまで短時間ポーリングしてからパネルを並べ替える。
+ */
+function updatePanelOrderWhenReady(id, tries = 20) {
+    const info = insoles[id].device_information;
+    if (info && typeof info.mount_position !== 'undefined') {
+        updatePanelOrder();
+        return;
+    }
+    if (tries <= 0) return;
+    setTimeout(() => updatePanelOrderWhenReady(id, tries - 1), 250);
+}
+
 window.onload = function () {
     for (let id = 0; id < 2; id++) {
         buildInsoleToolkit(
@@ -126,6 +158,12 @@ window.onload = function () {
         };
         insole.lostData = function (serial_number, serial_number_prev) {
             console.warn(`INSOLE${this.id}: lost packets ${serial_number_prev} -> ${serial_number}`);
+        };
+        insole.onConnect = function () {
+            updatePanelOrderWhenReady(this.id);
+        };
+        insole.onReconnectSuccess = function () {
+            updatePanelOrderWhenReady(this.id);
         };
     }
 

--- a/examples/hula-motion-sonifier/app.js
+++ b/examples/hula-motion-sonifier/app.js
@@ -2315,6 +2315,13 @@
       updateAudioControls();
       $("audio-state").textContent = "音声オン";
       $("audio-state").classList.add("is-on");
+      const enableButton = $("enable-audio");
+      if (enableButton) {
+        enableButton.classList.remove("attention");
+        enableButton.classList.add("is-enabled");
+        enableButton.textContent = "🔊 音声オン";
+        enableButton.disabled = true;
+      }
       setGlobalStatus("音声を有効化しました。Kāholo/Hela/ʻAmiのフェイズ音が鳴ります。");
     } catch (error) {
       setGlobalStatus(error.message, true);

--- a/examples/hula-motion-sonifier/index.html
+++ b/examples/hula-motion-sonifier/index.html
@@ -67,6 +67,29 @@
       background: var(--yellow);
     }
 
+    /* 音はブラウザ仕様上クリックしないと鳴らせないため、
+       有効化されるまでボタンを強調表示する */
+    #enable-audio.attention {
+      animation: pulse-audio 1.5s ease-in-out infinite;
+      font-size: 1.05em;
+    }
+
+    #enable-audio.is-enabled {
+      animation: none;
+      color: #071618;
+      background: #bfe9c9;
+      cursor: default;
+    }
+
+    @keyframes pulse-audio {
+      0%, 100% {
+        box-shadow: 0 0 0 0 rgba(244, 196, 48, 0.85);
+      }
+      50% {
+        box-shadow: 0 0 0 12px rgba(244, 196, 48, 0);
+      }
+    }
+
     a {
       color: inherit;
     }
@@ -1567,7 +1590,7 @@
         </div>
 
         <div class="top-actions">
-          <button id="enable-audio" type="button" class="warning">音を有効化</button>
+          <button id="enable-audio" type="button" class="warning attention" title="ブラウザの自動再生制限のため、クリックするまで音は鳴りません">🔊 ここを押して音を有効化</button>
           <label class="audio-master-control" for="master-volume">
             出力音量
             <input id="master-volume" type="range" min="0" max="100" step="1" value="82">

--- a/index.html
+++ b/index.html
@@ -365,13 +365,6 @@
       color: rgba(255, 255, 255, 0.74);
     }
 
-    .two-col {
-      display: grid;
-      grid-template-columns: minmax(0, 1.02fr) minmax(320px, 0.98fr);
-      gap: 54px;
-      align-items: center;
-    }
-
     .feature-list {
       display: grid;
       gap: 18px;
@@ -404,98 +397,6 @@
     .feature-item p {
       margin-bottom: 0;
       color: var(--muted);
-    }
-
-    .insole-visual {
-      position: relative;
-      min-height: 440px;
-      display: grid;
-      place-items: center;
-      background: #eef3f6;
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      overflow: hidden;
-    }
-
-    .insole-shape {
-      position: relative;
-      width: 230px;
-      height: 360px;
-      border-radius: 54% 46% 42% 48% / 30% 28% 72% 70%;
-      background: #fdfefe;
-      box-shadow: 0 18px 44px rgba(15, 28, 34, 0.16);
-      transform: rotate(-7deg);
-    }
-
-    .insole-shape::before {
-      content: "";
-      position: absolute;
-      inset: 20px 28px;
-      border: 1px solid rgba(49, 70, 80, 0.16);
-      border-radius: 54% 46% 42% 48% / 30% 28% 72% 70%;
-    }
-
-    .sensor-dot {
-      position: absolute;
-      width: 36px;
-      height: 36px;
-      border-radius: 50%;
-      background: var(--cyan);
-      border: 6px solid rgba(69, 230, 230, 0.28);
-      background-clip: padding-box;
-    }
-
-    .sensor-dot.orange {
-      background: var(--orange);
-      border-color: rgba(255, 96, 64, 0.28);
-    }
-
-    .sensor-dot.green {
-      background: var(--green);
-      border-color: rgba(112, 196, 111, 0.28);
-    }
-
-    .sensor-dot:nth-child(1) {
-      top: 62px;
-      left: 76px;
-    }
-
-    .sensor-dot:nth-child(2) {
-      top: 92px;
-      right: 54px;
-    }
-
-    .sensor-dot:nth-child(3) {
-      top: 150px;
-      left: 52px;
-    }
-
-    .sensor-dot:nth-child(4) {
-      top: 170px;
-      right: 62px;
-    }
-
-    .sensor-dot:nth-child(5) {
-      bottom: 96px;
-      left: 72px;
-    }
-
-    .sensor-dot:nth-child(6) {
-      bottom: 54px;
-      right: 74px;
-    }
-
-    .visual-caption {
-      position: absolute;
-      left: 18px;
-      right: 18px;
-      bottom: 18px;
-      display: flex;
-      justify-content: space-between;
-      gap: 12px;
-      color: #43505b;
-      font-size: 13px;
-      font-weight: 400;
     }
 
     .product-showcase {
@@ -825,7 +726,6 @@
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
 
-      .two-col,
       .product-showcase,
       .award-grid,
       .quick-start,
@@ -908,16 +808,6 @@
         width: min(100% - 24px, var(--max));
       }
 
-      .insole-visual {
-        min-height: 380px;
-      }
-
-      .insole-shape {
-        width: 190px;
-        height: 306px;
-      }
-
-      .visual-caption,
       .notice,
       .footer-inner {
         flex-direction: column;
@@ -999,8 +889,8 @@
     </section>
 
     <section class="section" id="about">
-      <div class="section-inner two-col">
-        <div>
+      <div class="section-inner">
+        <div class="section-head">
           <p class="eyebrow" data-i18n="aboutEyebrow">What is ORPHE INSOLE?</p>
           <h2 data-i18n="aboutTitle">Smart insole data, ready for web prototypes.</h2>
           <p class="lead" data-i18n="aboutLead">
@@ -1026,21 +916,6 @@
                 <p data-i18n-html="feature3Body">Use <code>new Orphe(...)</code> or the clearer <code>new OrpheInsole(...)</code> alias while keeping familiar callbacks.</p>
               </div>
             </div>
-          </div>
-        </div>
-
-        <div class="insole-visual" aria-label="Pressure sensor layout illustration" data-i18n-aria-label="insoleVisualLabel">
-          <div class="insole-shape">
-            <span class="sensor-dot orange"></span>
-            <span class="sensor-dot"></span>
-            <span class="sensor-dot green"></span>
-            <span class="sensor-dot"></span>
-            <span class="sensor-dot orange"></span>
-            <span class="sensor-dot green"></span>
-          </div>
-          <div class="visual-caption">
-            <span data-i18n="visualCaption1">Pressure map concept</span>
-            <span>INSOLE SENSOR_VALUES</span>
           </div>
         </div>
       </div>
@@ -1387,8 +1262,6 @@
         feature2Body: "Open the examples in Chrome or Edge, connect with Web Bluetooth, and start inspecting live packets.",
         feature3Title: "Compatible with existing ORPHE style APIs",
         feature3Body: "Use <code>new Orphe(...)</code> or the clearer <code>new OrpheInsole(...)</code> alias while keeping familiar callbacks.",
-        insoleVisualLabel: "Pressure sensor layout illustration",
-        visualCaption1: "Pressure map concept",
         productImageCaption: "Evaluation Kit",
         productEyebrow: "Official product details",
         productTitle: "A pressure and motion platform inside the insole.",
@@ -1520,8 +1393,6 @@
         feature2Body: "ChromeまたはEdgeでサンプルを開き、Web Bluetoothで接続すれば、ライブパケットをすぐ確認できます。",
         feature3Title: "既存のORPHE APIスタイルと互換",
         feature3Body: "<code>new Orphe(...)</code> でも、より分かりやすい <code>new OrpheInsole(...)</code> でも利用でき、既存のコールバック互換を保ちます。",
-        insoleVisualLabel: "圧力センサーレイアウトのイラスト",
-        visualCaption1: "圧力マップのイメージ",
         productImageCaption: "Evaluation Kit",
         productEyebrow: "公式製品情報",
         productTitle: "インソール内の圧力・モーションプラットフォーム。",


### PR DESCRIPTION
実機テスト（v1.1.0）のフィードバック3件への対応です。

## 変更内容

### 1. VISUALIZE: L/R に応じたパネル自動入れ替え
どちらの接続トグルから接続しても、`device_information.mount_position`（bit0: 0=LEFT, 1=RIGHT）を読んで **左足デバイスは左パネル、右足デバイスは右パネル** に表示されるようにしました。Bootstrap の row（flex）上で各カラムの `order` を切り替える方式で、ツールキットのヘッダ（周波数・L/Rバッジ・バッテリー）ごと移動します。再接続成功時にも再判定します。

### 2. hula-motion-sonifier: 「音を有効化」ボタンの強調
ブラウザの自動再生制限でクリック必須なことが分かりにくかったため:
- ボタンを `🔊 ここを押して音を有効化` に変更し、パルスアニメーションで強調
- 有効化後は `🔊 音声オン` 表示（緑系）に変わり、ボタンは無効化
- 説明のツールチップを追加

### 3. ランディングページ: 圧力マップのイメージ図を削除
About セクションの抽象的なインソール図（sensor-dot のイラスト）を削除し、不要になった CSS（約130行）と日英の i18n キーも除去。セクションは他と同じ section-head レイアウトに変更。

## 検証
- `npm test` 全パス（構文チェック + 4テスト）
- src/ は未変更のため dist/・JSDoc の再生成は不要

## 実機での確認ポイント
- [ ] VISUALIZE: 左トグルで右足デバイスを接続 → 右パネルに表示される（逆も）
- [ ] VISUALIZE: 2台接続時に L が左・R が右に並ぶ
- [ ] hula: 初期表示でボタンが目立ち、クリック後に「音声オン」になる
- [ ] ランディング: About セクションのレイアウト崩れがない

https://claude.ai/code/session_01LHqCv54BQYZS1yayomuRQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHqCv54BQYZS1yayomuRQ9)_